### PR TITLE
Define raw_input() in Python 3

### DIFF
--- a/create_training_dataset.py
+++ b/create_training_dataset.py
@@ -13,6 +13,11 @@ logger = logging.getLogger('create_training_dataset')
 
 _COCO_ZIP_URL = 'http://images.cocodataset.org/zips/train2014.zip'
 
+try:
+    raw_input          # Python 3
+except NameError:
+    raw_input = input  # Python 3
+
 
 class DatasetCreator(object):
     """A class to preprocess images from the COCO training data.


### PR DESCRIPTION
__raw_input()__ was removed  in Python 3 in favor of a modified version of __input()__.